### PR TITLE
Update example in the DataFrame documentation.

### DIFF
--- a/docs/source/user-guide/dataframe.md
+++ b/docs/source/user-guide/dataframe.md
@@ -44,7 +44,7 @@ let df = df.filter(col("a").lt_eq(col("b")))?
            .aggregate(vec![col("a")], vec![min(col("b"))])?
            .limit(0, Some(100))?;
 // Print results
-df.show();
+df.show().await?;
 ```
 
 The DataFrame API is well documented in the [API reference on docs.rs](https://docs.rs/datafusion/latest/datafusion/dataframe/struct.DataFrame.html).


### PR DESCRIPTION
In the [documentation for DataFrame](https://arrow.apache.org/datafusion/user-guide/dataframe.html), a copy/paste of the example has a couple
of compile errors.

`.show` returns a `Future`, and the `Future` returns a `Result`.